### PR TITLE
Updating to latest p4 version:

### DIFF
--- a/csbuild/_utils.py
+++ b/csbuild/_utils.py
@@ -706,7 +706,7 @@ def ChunkedBuild( ):
 		obj = GetSourceObjPath( owningProject, chunkname, sourceIsChunkPath=owningProject.ContainsChunk( chunkname ) )
 		for chunk in owningProject.chunks:
 			if GetChunkName( owningProject.outputName, chunk ) == chunkname:
-				if os.access(obj , os.F_OK):
+				if not owningProject.activeToolchain.Compiler().SupportsObjectScraping() and os.access(obj , os.F_OK):
 					os.remove(obj)
 					log.LOG_WARN_NOPUSH(
 						"Breaking chunk ({0}) into individual files to improve future iteration turnaround.".format(
@@ -802,11 +802,15 @@ def ChunkedBuild( ):
 					#This keeps large builds fast through the chunked build, without sacrificing the speed of smaller
 					#incremental builds (except on the first build after the chunk)
 					os.remove( obj )
-					add_chunk = chunk
+					if owningProject.activeToolchain.Compiler().SupportsObjectScraping():
+						add_chunk = sources_in_this_chunk
+					else:
+						add_chunk = chunk
 					if project.useChunks and not _shared_globals.disable_chunks:
-						log.LOG_WARN_NOPUSH(
-							"Breaking chunk ({0}) into individual files to improve future iteration turnaround.".format(
-								chunk ) )
+						if owningProject.activeToolchain.Compiler().SupportsObjectScraping():
+							log.LOG_WARN_NOPUSH(
+								"Breaking chunk ({0}) into individual files to improve future iteration turnaround.".format(
+									chunk ) )
 
 						for filename in chunk:
 							owningProject.splitChunks[filename] = chunkname

--- a/csbuild/scrapers/COFF.py
+++ b/csbuild/scrapers/COFF.py
@@ -1,7 +1,7 @@
 from . import scraper
 import struct
 
-from . import BYTE, SHORT, LONG
+from . import BYTE, SHORT, LONG, LONGLONG
 
 class SymbolClass:
 	STATIC = 2

--- a/csbuild/scrapers/ELF.py
+++ b/csbuild/scrapers/ELF.py
@@ -1,0 +1,189 @@
+from . import scraper
+
+from . import BYTE, SHORT, LONG, LONGLONG
+
+class ElfClass:
+	cNone = 0
+	c32 = 1
+	c64 = 2
+
+class ELFScraper(scraper.Scraper):
+	def __init__(self):
+		scraper.Scraper.__init__(self)
+		self._scrapeLocations = {}
+		self._header = None
+
+	def RemoveSharedSymbols(self, objectsWithSymbols, objectToScrape):
+		for object in objectsWithSymbols:
+			self._collectSymbols(object)
+		self._eraseSymbols(objectToScrape)
+
+	def _readHeader(self):
+		magic = b'';
+		self.SkipBytes(1);
+		magic += self.ReadChar()
+		magic += self.ReadChar()
+		magic += self.ReadChar()
+		assert(magic == b'ELF')
+
+		class Header(object):
+			def __init__(self, scraper):
+				self.cls = scraper.ReadByte()
+
+				scraper.SkipBytes(11)
+				scraper.SkipBytes(SHORT + SHORT + LONG)
+
+				if self.cls == ElfClass.c32:
+					scraper.SkipBytes(LONG + LONG)
+					self.shoff = scraper.ReadLong()
+				else:
+					scraper.SkipBytes(LONGLONG + LONGLONG)
+					self.shoff = scraper.ReadLongLong()
+
+				scraper.SkipBytes(LONG + SHORT + SHORT + SHORT + SHORT)
+				self.shnum = scraper.ReadShort()
+				self.shstrndx = scraper.ReadShort()
+
+		return Header(self)
+
+	def _readSections(self, header):
+		sections = []
+		class Section(object):
+			def __init__(self, scraper):
+				self.nameOffset = scraper.ReadLong()
+				self.name = b''
+				self.type = scraper.ReadLong()
+
+				if header.cls == ElfClass.c32:
+					self.flags = scraper.ReadLong()
+					self.addr = scraper.ReadLong()
+					self.offset = scraper.ReadLong()
+					self.size = scraper.ReadLong()
+				else:
+					self.flags = scraper.ReadLongLong()
+					self.addr = scraper.ReadLongLong()
+					self.offset = scraper.ReadLongLong()
+					self.size = scraper.ReadLongLong()
+
+				self.link = scraper.ReadLong()
+				self.info = scraper.ReadLong()
+
+				if header.cls == ElfClass.c32:
+					self.addralign = scraper.ReadLong()
+					self.entsize = scraper.ReadLong()
+				else:
+					self.addralign = scraper.ReadLongLong()
+					self.entsize = scraper.ReadLongLong()
+
+				self.data = None
+
+		for i in range(header.shnum):
+			sections.append(Section(self))
+
+		for i in range(header.shnum):
+			self.SeekToPosition(sections[header.shstrndx].offset + sections[i].nameOffset)
+			oneChar = self.ReadChar()
+			while oneChar != '\0':
+				sections[i].name += oneChar
+				oneChar = self.ReadChar()
+			if sections[i].name == ".strtab":
+				symStrSection = sections[i]
+
+		return sections, symStrSection
+
+	def _collectSymbols(self, object):
+		self.Open(object, "rb")
+
+		header = self._readHeader()
+
+		self.SeekToPosition(header.shoff)
+
+		sections, symStrSection = self._readSections(header)
+
+		for i in range(header.shnum):
+			if sections[i].type == 2:
+				self.SeekToPosition(sections[i].offset)
+				while self.GetPosition() - sections[i].offset < sections[i].size:
+					pos = self.GetPosition()
+					if header.cls == ElfClass.c32:
+						nameOffset = self.ReadLong()
+						value = self.ReadLong()
+						size = self.ReadLong()
+						info = self.ReadByte()
+						other = self.ReadByte()
+						shndx = self.ReadShort()
+					else:
+						nameOffset = self.ReadLong()
+						info = self.ReadByte()
+						other = self.ReadByte()
+						shndx = self.ReadShort()
+						value = self.ReadLongLong()
+						size = self.ReadLongLong()
+				
+					pos = self.GetPosition()
+					self.SeekToPosition(symStrSection.offset + nameOffset)
+					name = b''
+					oneChar = self.ReadChar()
+					while oneChar != '\0':
+						name += oneChar
+						oneChar = self.ReadChar()
+					if info == 17 or info == 18:
+						self._scrapeLocations[name] = pos
+					self.SeekToPosition(pos)
+		self.Close()
+
+	def _eraseSymbols(self, object):
+		self.Open(object, "rb+")
+
+		header = self._readHeader()
+
+		self.SeekToPosition(header.shoff)
+
+		sections, symStrSection = self._readSections(header)
+
+		for i in range(header.shnum):
+			if sections[i].type == 2:
+				self.SeekToPosition(sections[i].offset)
+				while self.GetPosition() - sections[i].offset < sections[i].size:
+					startpos = self.GetPosition()
+					if header.cls == ElfClass.c32:
+						nameOffset = self.ReadLong()
+						value = self.ReadLong()
+						size = self.ReadLong()
+						info = self.ReadByte()
+						other = self.ReadByte()
+						shndx = self.ReadShort()
+					else:
+						nameOffset = self.ReadLong()
+						info = self.ReadByte()
+						other = self.ReadByte()
+						shndx = self.ReadShort()
+						value = self.ReadLongLong()
+						size = self.ReadLongLong()
+				
+					pos = self.GetPosition()
+					self.SeekToPosition(symStrSection.offset + nameOffset)
+					name = b''
+					oneChar = self.ReadChar()
+					while oneChar != '\0':
+						name += oneChar
+						oneChar = self.ReadChar()
+					
+					if name in self._scrapeLocations:
+						self.SeekToPosition(startpos + LONG)
+						
+						if header.cls == ElfClass.c32:
+							self.WriteLong(0)
+							self.WriteLong(0)
+							self.WriteByte(16)
+							self.WriteByte(0)
+							self.WriteShort(0)
+						else:
+							self.WriteByte(16)
+							self.WriteByte(0)
+							self.WriteShort(0)
+							self.WriteLongLong(0)
+							self.WriteLongLong(0)
+					self.SeekToPosition(pos)
+		self.Close()					
+

--- a/csbuild/scrapers/__init__.py
+++ b/csbuild/scrapers/__init__.py
@@ -1,3 +1,4 @@
 BYTE = 1
 SHORT = 2
 LONG = 4
+LONGLONG = 8

--- a/csbuild/scrapers/scraper.py
+++ b/csbuild/scrapers/scraper.py
@@ -1,6 +1,6 @@
 import struct
 
-from . import BYTE, SHORT, LONG
+from . import BYTE, SHORT, LONG, LONGLONG
 
 class Scraper(object):
 	def __init__(self):
@@ -31,16 +31,28 @@ class Scraper(object):
 		self._file.write(struct.pack("H", data))
 
 	def ReadLong(self):
-		return struct.unpack("l", self._file.read(LONG))[0]
+		return struct.unpack("i", self._file.read(LONG))[0]
 
 	def WriteLong(self, data):
-		self._file.write(struct.pack("l", data))
+		self._file.write(struct.pack("i", data))
 
 	def ReadUnsignedLong(self):
-		return struct.unpack("L", self._file.read(LONG))[0]
+		return struct.unpack("I", self._file.read(LONG))[0]
 
 	def WriteUnsignedLong(self, data):
-		self._file.write(struct.pack("L", data))
+		self._file.write(struct.pack("I", data))
+
+	def ReadLongLong(self):
+		return struct.unpack("q", self._file.read(LONGLONG))[0]
+
+	def WriteLongLong(self, data):
+		self._file.write(struct.pack("q", data))
+
+	def ReadUnsignedLongLong(self):
+		return struct.unpack("Q", self._file.read(LONGLONG))[0]
+
+	def WriteUnsignedLongLong(self, data):
+		self._file.write(struct.pack("Q", data))
 
 	def ReadBytes(self, numBytes):
 		return self._file.read(numBytes)

--- a/csbuild/toolchain.py
+++ b/csbuild/toolchain.py
@@ -156,8 +156,8 @@ class SettingsOverrider( object ):
 		:type args: an arbitrary number of strings
 		:param args: The list of files to be excluded.
 		"""
-		if "excludeFilesTempTemp" not in self._settingsOverrides:
-			self._settingsOverrides["excludeFilesTempTemp"] = []
+		if "excludeFilesTemp" not in self._settingsOverrides:
+			self._settingsOverrides["excludeFilesTemp"] = []
 
 		args = list( args )
 		newargs = []
@@ -165,7 +165,7 @@ class SettingsOverrider( object ):
 			arg = _utils.FixupRelativePath( arg )
 			arg = _utils.PathWorkingDirPair( arg )
 			newargs.append( arg )
-		self._settingsOverrides["excludeFilesTempTemp"] += newargs
+		self._settingsOverrides["excludeFilesTemp"] += newargs
 		self._settingsOverrides["tempsDirty"] = True
 
 
@@ -1457,8 +1457,14 @@ class compilerBase( toolBase ):
 		"""
 		pass
 
+	def SupportsObjectScraping(self):
+		return False
+
 	def GetObjectScraper(self):
 		return None
+
+	def SupportsDummyObjects(self):
+		return False
 
 	def MakeDummyObjects(self, objList):
 		pass

--- a/csbuild/toolchain_gcc.py
+++ b/csbuild/toolchain_gcc.py
@@ -32,6 +32,7 @@ from . import _shared_globals
 from . import toolchain
 import csbuild
 from . import log
+from .scrapers import ELF
 
 class gccBase( object ):
 	def __init__( self ):
@@ -418,6 +419,14 @@ class GccCompiler( gccBase, toolchain.compilerBase ):
 		:type s: str
 		"""
 		self.cStandard = s
+
+
+	def SupportsObjectScraping(self):
+		return True
+
+
+	def GetObjectScraper(self):
+		return ELF.ELFScraper()
 
 
 class GccLinker( gccBase, toolchain.linkerBase ):

--- a/csbuild/toolchain_gcc_darwin.py
+++ b/csbuild/toolchain_gcc_darwin.py
@@ -145,6 +145,13 @@ class GccCompilerDarwin( GccDarwinBase, toolchain_gcc.GccCompiler ):
 		)
 		return ret
 
+	def SupportsObjectScraping(self):
+		return False
+
+
+	def GetObjectScraper(self):
+		return None
+
 
 class GccLinkerDarwin( GccDarwinBase, toolchain_gcc.GccLinker ):
 	def __init__( self, shared ):

--- a/csbuild/toolchain_ios.py
+++ b/csbuild/toolchain_ios.py
@@ -60,12 +60,22 @@ class iOSBase( object ):
 				DEFAULT_DEVICE_SDK_DIR = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
 				DEFAULT_SIMULATOR_SDK_DIR = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
 
+				# In Python3, these will need to be bytes rather than strings for the decoding below.
+				if sys.version_info >= (3, 0):
+					DEFAULT_DEVICE_SDK_DIR = DEFAULT_DEVICE_SDK_DIR.encode("utf-8")
+					DEFAULT_SIMULATOR_SDK_DIR = DEFAULT_SIMULATOR_SDK_DIR.encode("utf-8")
+
 			try:
 				DEFAULT_DEVICE_SDK_VERSION = subprocess.check_output(["xcrun", "--sdk", "iphoneos", "--show-sdk-version"])
 				DEFAULT_SIMULATOR_SDK_VERSION = subprocess.check_output(["xcrun", "--sdk", "iphonesimulator", "--show-sdk-version"])
 			except:
 				DEFAULT_DEVICE_SDK_VERSION = ""
 				DEFAULT_SIMULATOR_SDK_VERSION = ""
+
+				# In Python3, these will need to be bytes rather than strings for the decoding below.
+				if sys.version_info >= (3, 0):
+					DEFAULT_DEVICE_SDK_VERSION = DEFAULT_DEVICE_SDK_VERSION.encode("utf-8")
+					DEFAULT_SIMULATOR_SDK_VERSION = DEFAULT_SIMULATOR_SDK_VERSION.encode("utf-8")
 
 			if sys.version_info >= (3, 0):
 				DEFAULT_DEVICE_SDK_DIR = DEFAULT_DEVICE_SDK_DIR.decode("utf-8")

--- a/csbuild/toolchain_msvc.py
+++ b/csbuild/toolchain_msvc.py
@@ -427,9 +427,9 @@ class MsvcCompiler( MsvcBase, toolchain.compilerBase ):
 
 	def preLinkStep(self, project):
 		if project.cHeaderFile:
-			self.shared._project_settings.extraObjs.add("{}.obj".format(project.cHeaderFile.rsplit(".", 1)[0]))
+			project.extraObjs.add("{}.obj".format(project.cHeaderFile.rsplit(".", 1)[0]))
 		if project.cppHeaderFile:
-			self.shared._project_settings.extraObjs.add("{}.obj".format(project.cppHeaderFile.rsplit(".", 1)[0]))
+			project.extraObjs.add("{}.obj".format(project.cppHeaderFile.rsplit(".", 1)[0]))
 
 
 	def _getExtendedPrecompilerArgs( self, base_cmd, force_include_file, output_obj, input_file ):
@@ -526,8 +526,16 @@ class MsvcCompiler( MsvcBase, toolchain.compilerBase ):
 		return fileName.rsplit( ".", 1 )[0] + ".pch"
 
 
+	def SupportsObjectScraping(self):
+		return True
+
+
 	def GetObjectScraper(self):
 		return COFF.COFFScraper()
+
+
+	def SupportsDummyObjects(self):
+		return True
 
 
 	def MakeDummyObjects(self, objList):
@@ -659,10 +667,10 @@ class MsvcLinker( MsvcBase, toolchain.linkerBase ):
 				splitName = os.path.splitext(dependLibName)[0]
 				if ( splitName == lib or splitName == "lib{}".format( lib ) ):
 					found = True
-					args += '"{}" '.format( dependLibName )
+					args += '"{}"\n'.format( dependLibName )
 					break
 			if not found:
-				args += '"{}" '.format( self._actual_library_names[lib] )
+				args += '"{}"\n'.format( self._actual_library_names[lib] )
 
 		return args
 


### PR DESCRIPTION
- Fixed a Python3 error when the ios toolchain's device/simulator default paths are used. (c/o @brandonmbare)
- Added some android toolchain fixes. (c/o @brandonmbare)
- Fix exclude files on toolchains.
- Fix for compiling multiple toolchains with architectures that exist only in a subset of the toolchains throwing an error. (For example, compiling msvc and android for x64 and armeabi-v7a).
- Fix "precompiled object not linked in" error in msvc toolchain.
- Fixed an issue with header dependency discovery
- Enabled coff scraping in the msvc toolchain so that iterating on chunks is faster.
- Added ELF scraper and enabled it for gcc and android toolchains. Explicitly disabled it for darwin and ios as they use the Mach-O format and will need a different type of scraper.
- Fixed a race condition where multiple threads could be calling ResolveFilesAndDirectories() at the same time and relying on a chdir() that was getting changed out from under them. Instead of using abspath() from the chdir, I switched that to normpath(join(savedWorkingDirectory, relativeDirectory)), which according to the documentation is what abspath() resolves to for most platforms.